### PR TITLE
Update Docker Images

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.6"
 
 services:
   postgres:
-    image: postgres:13
+    image: postgres:13-alpine
     restart: always
     volumes:
       - hasura_ci_db_data:/var/lib/postgresql/data
@@ -13,7 +13,7 @@ services:
       POSTGRES_PASSWORD: postgrespassword
 
   graphql-engine:
-    image: hasura/graphql-engine:v2.3.1.cli-migrations-v3
+    image: hasura/graphql-engine:v2.4.0.cli-migrations-v3
     volumes:
       - ./hasura/migrations:/hasura-migrations
       - ./hasura/metadata:/hasura-metadata
@@ -75,20 +75,16 @@ services:
   #
   # It is used to generate presigned image upload/download urls for the frontend (this is done via Hasura Action REST API handlers in Next.js)
   minio:
-    image: minio/minio:RELEASE.2021-06-17T00-10-46Z
+    image: minio/minio:latest
     volumes:
       - minio_data:/data
     ports:
       - 9000:9000
+      - 9001:9001
     environment:
       MINIO_ROOT_USER: minio
       MINIO_ROOT_PASSWORD: minio123
-    command: server /data
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
-      interval: 30s
-      timeout: 20s
-      retries: 3
+    command: minio server /data/minio --console-address ":9001"
 
 volumes:
   minio_data:


### PR DESCRIPTION
Here is my small contribution.

**Changed:**
- Updated `graphql-engine` to `v2.4.0.cli-migrations-v3`
- Using `postgres:13-alpine` instead of regular postgres image for smaller size
- Updated `minio` to the latest version

Thank you.